### PR TITLE
added optional 'network interface' address option

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function(opts) {
 
     socket.bind(port, function() {
       if (opts.multicast !== false) {
-        socket.addMembership(ip)
+        socket.addMembership(ip, opts.interface)
         socket.setMulticastTTL(opts.ttl || 255)
         socket.setMulticastLoopback(opts.loopback !== false)
       }


### PR DESCRIPTION
I was unable to receive some queries and found out that explicitly specifying a multicast interface in socket.addMembership solved this. I'm not sure exactly why (addMembership should add memebership to all valid interfaces by default), but it looks like this is not a rare issue: http://stackoverflow.com/questions/14130560/nodejs-udp-multicast-how-to

Therefore, I believe adding an option to specify the interface argument for the addMembership might be useful. I'm not very familiar with UDP, however - perhaps it would be even better to make it possible to specify multiple interfaces, etc.