### PR TITLE
generate an error event for errors related to socket

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function (opts) {
     })
 
     socket.on('error', function (err) {
-      that.emit('warning', err)
+      that.emit('error', err)
     })
 
     socket.on('message', function (message, rinfo) {


### PR DESCRIPTION
Currently both errors generated by socket (e.g., because address is in use) and decoding errors are reported as warnings. I would suggest to generate an error event for first category since this is related to local setup of connections etc. while second category is generated externally.