### PR TITLE
Parse TXT RDATA content according to DNS-SD

### DIFF
--- a/test.js
+++ b/test.js
@@ -123,15 +123,32 @@ test('SRV record', function (dns, t) {
 })
 
 test('TXT record', function (dns, t) {
+  var data = new Buffer('black box')
+
   dns.once('query', function (packet) {
     t.same(packet.questions.length, 1, 'one question')
     t.same(packet.questions[0], {name: 'hello-world', type: 'TXT', class: 1})
-    dns.response([{type: 'TXT', name: 'hello-world', ttl: 120, data: 'hello=world,hej=verden'}])
+    dns.response([{type: 'TXT', name: 'hello-world', ttl: 120, data: data}])
   })
 
   dns.once('response', function (packet) {
     t.same(packet.answers.length, 1, 'one answer')
-    t.same(packet.answers[0], {type: 'TXT', name: 'hello-world', ttl: 120, data: 'hello=world,hej=verden', class: 1})
+    t.same(packet.answers[0], {type: 'TXT', name: 'hello-world', ttl: 120, data: data, class: 1})
+    dns.destroy(function () {
+      t.end()
+    })
+  })
+
+  dns.query('hello-world', 'TXT')
+})
+
+test('TXT record - empty', function (dns, t) {
+  dns.once('query', function (packet) {
+    dns.response([{type: 'TXT', name: 'hello-world', ttl: 120}])
+  })
+
+  dns.once('response', function (packet) {
+    t.same(packet.answers[0], {type: 'TXT', name: 'hello-world', ttl: 120, data: new Buffer('00', 'hex'), class: 1})
     dns.destroy(function () {
       t.end()
     })


### PR DESCRIPTION
This PR does 2 things:

1. It improves the TXT RDATA parser so it now correctly parses RDATA containing more than one character-string (see [RFC 1035](https://tools.ietf.org/html/rfc1035) section 3.3.14)

2. It expects the TXT RDATA to conform to the RFC 6763 spec meaning that each character-string will be parsed as a key/value pair. For more info see: https://tools.ietf.org/html/rfc6763#section-6

This implies the following breaking API chages:

- On a `response` event, the `data` property on a TXT record will now be a JavaScript object instead of a string
  - Keys are case-insensitive and will be lowercased
  - Keys with no value will be parsed as booleans with the value `true`

- When responding with a TXT record using `mdns.respond`, the `data` property on a TXT record should now be a single level JavaScript object, e.g. `{key1: 'val', key2: 'val'}`

Closes #16