### PR TITLE
Default to ANY query if no type given

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ module.exports = function (opts) {
     if (typeof type === 'function') return that.query(q, null, type)
     if (!cb) cb = noop
 
-    if (typeof q === 'string') q = [{name: q, type: type || 'A'}]
+    if (typeof q === 'string') q = [{name: q, type: type || 'ANY'}]
     if (Array.isArray(q)) q = {type: 'query', questions: q}
 
     q.type = 'query'

--- a/test.js
+++ b/test.js
@@ -36,6 +36,18 @@ test('works', function (dns, t) {
   })
 })
 
+test('ANY query', function (dns, t) {
+  dns.once('query', function (packet) {
+    t.same(packet.questions.length, 1, 'one question')
+    t.same(packet.questions[0], {name: 'hello-world', type: 'ANY', class: 1})
+    dns.destroy(function () {
+      t.end()
+    })
+  })
+
+  dns.query('hello-world', 'ANY')
+})
+
 test('A record', function (dns, t) {
   dns.once('query', function (packet) {
     t.same(packet.questions.length, 1, 'one question')


### PR DESCRIPTION
Previously the default query type would be A-records, but now all record types are queried.

Closes #15 