### PR TITLE
Use official respond() function instead of response() alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ mdns.respond({
 The following shorthands are equivalent
 
 ``` js
-mdns.response([{name:'brunhilde.local', type:'A', data:'192.158.1.5'}])
-mdns.response({
+mdns.respond([{name:'brunhilde.local', type:'A', data:'192.158.1.5'}])
+mdns.respond({
   answers: [{name:'brunhilde.local', type:'A', data:'192.158.1.5'}]
 })
 ```

--- a/test.js
+++ b/test.js
@@ -52,7 +52,7 @@ test('A record', function (dns, t) {
   dns.once('query', function (packet) {
     t.same(packet.questions.length, 1, 'one question')
     t.same(packet.questions[0], {name: 'hello-world', type: 'A', class: 1})
-    dns.response([{type: 'A', name: 'hello-world', ttl: 120, data: '127.0.0.1'}])
+    dns.respond([{type: 'A', name: 'hello-world', ttl: 120, data: '127.0.0.1'}])
   })
 
   dns.once('response', function (packet) {
@@ -71,7 +71,7 @@ test('A record (two questions)', function (dns, t) {
     t.same(packet.questions.length, 2, 'two questions')
     t.same(packet.questions[0], {name: 'hello-world', type: 'A', class: 1})
     t.same(packet.questions[1], {name: 'hej.verden', type: 'A', class: 1})
-    dns.response([{type: 'A', name: 'hello-world', ttl: 120, data: '127.0.0.1'}, {type: 'A', name: 'hej.verden', ttl: 120, data: '127.0.0.2'}])
+    dns.respond([{type: 'A', name: 'hello-world', ttl: 120, data: '127.0.0.1'}, {type: 'A', name: 'hej.verden', ttl: 120, data: '127.0.0.2'}])
   })
 
   dns.once('response', function (packet) {
@@ -90,7 +90,7 @@ test('AAAA record', function (dns, t) {
   dns.once('query', function (packet) {
     t.same(packet.questions.length, 1, 'one question')
     t.same(packet.questions[0], {name: 'hello-world', type: 'AAAA', class: 1})
-    dns.response([{type: 'AAAA', name: 'hello-world', ttl: 120, data: 'fe80::5ef9:38ff:fe8c:ceaa'}])
+    dns.respond([{type: 'AAAA', name: 'hello-world', ttl: 120, data: 'fe80::5ef9:38ff:fe8c:ceaa'}])
   })
 
   dns.once('response', function (packet) {
@@ -108,7 +108,7 @@ test('SRV record', function (dns, t) {
   dns.once('query', function (packet) {
     t.same(packet.questions.length, 1, 'one question')
     t.same(packet.questions[0], {name: 'hello-world', type: 'SRV', class: 1})
-    dns.response([{type: 'SRV', name: 'hello-world', ttl: 120, data: {port: 11111, target: 'hello.world.com', priority: 10, weight: 12}}])
+    dns.respond([{type: 'SRV', name: 'hello-world', ttl: 120, data: {port: 11111, target: 'hello.world.com', priority: 10, weight: 12}}])
   })
 
   dns.once('response', function (packet) {
@@ -128,7 +128,7 @@ test('TXT record', function (dns, t) {
   dns.once('query', function (packet) {
     t.same(packet.questions.length, 1, 'one question')
     t.same(packet.questions[0], {name: 'hello-world', type: 'TXT', class: 1})
-    dns.response([{type: 'TXT', name: 'hello-world', ttl: 120, data: data}])
+    dns.respond([{type: 'TXT', name: 'hello-world', ttl: 120, data: data}])
   })
 
   dns.once('response', function (packet) {
@@ -144,7 +144,7 @@ test('TXT record', function (dns, t) {
 
 test('TXT record - empty', function (dns, t) {
   dns.once('query', function (packet) {
-    dns.response([{type: 'TXT', name: 'hello-world', ttl: 120}])
+    dns.respond([{type: 'TXT', name: 'hello-world', ttl: 120}])
   })
 
   dns.once('response', function (packet) {


### PR DESCRIPTION
The `response()` function is an alias for the `respond()` function which is the one documented in the README.md. When reading the tests it can be confusing to see the `response()` function being used since you don't know at first that it's just an alias.