### PR TITLE
add test: TXT record - data being a string

### DIFF
--- a/packets.js
+++ b/packets.js
@@ -83,7 +83,7 @@ header.decode = function (buf, offset) {
     ancount: buf.readUInt16BE(offset + 6),
     nscount: buf.readUInt16BE(offset + 8),
     arcount: buf.readUInt16BE(offset + 10)
-   }
+  }
 }
 
 header.encode = function (h, buf, offset) {

--- a/test.js
+++ b/test.js
@@ -142,6 +142,26 @@ test('TXT record', function (dns, t) {
   dns.query('hello-world', 'TXT')
 })
 
+test('TXT record - data being a string', function (dns, t) {
+  var data = 'Just came to say, hello!'
+
+  dns.once('query', function (packet) {
+    t.same(packet.questions.length, 1, 'one question')
+    t.same(packet.questions[0], {name: 'hello-world', type: 'TXT', class: 1})
+    dns.respond([{type: 'TXT', name: 'hello-world', ttl: 120, data: data}])
+  })
+
+  dns.once('response', function (packet) {
+    t.same(packet.answers.length, 1, 'one answer')
+    t.same(packet.answers[0], {type: 'TXT', name: 'hello-world', ttl: 120, data: data, class: 1})
+    dns.destroy(function () {
+      t.end()
+    })
+  })
+
+  dns.query('hello-world', 'TXT')
+})
+
 test('TXT record - empty', function (dns, t) {
   dns.once('query', function (packet) {
     dns.respond([{type: 'TXT', name: 'hello-world', ttl: 120}])


### PR DESCRIPTION
> WIP

While I was updating https://github.com/diasdavid/js-libp2p-mdns-discovery and testing it against go-mdns, I noticed that the 'data' field on TXT records is not being parsed as a string anymore (if the data field on the response was indeed a string), if a non object is passed, it always comes as a Buffer. Initially I thought it could be on purpose, but it seems this is happening 'only' (haven't tested with every single record) with TXT records, for e.g PTR or A records emit the response with the data field being a string just fine.

I've added a failing test on this PR, was trying to figure out what made TXT records differently (because it looks everything is using the same encoder/decoder), any thoughts @mafintosh ?