### PR TITLE
Add support for cache flush flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,20 +56,23 @@ got a response packet: { type: 'response',
   answers:
    [ { name: 'brunhilde.local',
        type: 'A',
-       class: 32769,
+       class: 1,
        ttl: 120,
+       flush: true,
        data: '192.168.1.5' } ],
   authorities: [],
   additionals:
    [ { name: 'brunhilde.local',
        type: 'A',
-       class: 32769,
+       class: 1,
        ttl: 120,
+       flush: true,
        data: '192.168.1.5' },
      { name: 'brunhilde.local',
        type: 'AAAA',
-       class: 32769,
+       class: 1,
        ttl: 120,
+       flush: true,
        data: 'fe80::5ef9:38ff:fe8c:ceaa' } ] }
 ```
 


### PR DESCRIPTION
This fixes the weird classes we've seen, e.g. `32769` which in binary is:

```
1000 0000 0000 0001
```

The 1st bit is actually not part of the class but is a "cache flush" flag, so the class value in this case is actually `1` and not `32769`.