### PR TITLE
Use opts.interface in bind operation...

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function (opts) {
   var bind = thunky(function (cb) {
     if (!port) return cb(null)
     socket.once('error', cb)
-    socket.bind(port, function () {
+    socket.bind(port, opts.interface, function () {
       socket.removeListener('error', cb)
       cb(null)
     })


### PR DESCRIPTION
When using the interface option the interface used to send mDNS queries is still selected automatically and in some cases ends up on the wrong interface.

I made a minute change so the interface option is used when binding the socket to ensure the same interface that is specified for listening is also the interface that is used to send queries.

This makes it possible to use multicast-dns on systems with multiple interfaces, i.e. when running on a system that includes a virtual network for VMs, by specifying which interface to use.