### PR TITLE
Catch and emit error on socket.addMembership

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,11 @@ module.exports = function (opts) {
   socket.on('listening', function () {
     if (!port) port = me.port = socket.address().port
     if (opts.multicast !== false) {
-      socket.addMembership(ip, opts.interface)
+      try {
+        socket.addMembership(ip, opts.interface)
+      } catch (err) {
+        that.emit('error', err)
+      }
       socket.setMulticastTTL(opts.ttl || 255)
       socket.setMulticastLoopback(opts.loopback !== false)
     }


### PR DESCRIPTION
socket.addMembership throws an error on network issues (no network). This commit catches and emits the error so that the error can be handled elsewhere instead of crashing the library.
