### PR TITLE
Add Typescript 2.x typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,72 @@
+// Type definitions for multicast-dns 6.1.0
+// Project: https://github.com/mafintosh/multicast-dns
+// Definitions by: Iain McGinniss <https://github.com/iainmcgin>
+
+/// <reference types="node" />
+
+import { AddressInfo } from 'dgram';
+import * as packet from 'dns-packet';
+
+type Callback = (err: Error) => any;
+
+interface MulticastDnsOptions {
+    /**
+     * Use UDP multicasting?
+     */
+    multicast?: boolean;
+
+    /**
+     * Interface on which to listen and perform mdns operations.
+     */
+    interface?: string;
+
+    /**
+     * The UDP port to listen on.
+     */
+    port?: number;
+
+    /**
+     * The IP address to listen on.
+     */
+    ip?: string;
+
+    /**
+     * The multicast TTL.
+     */
+    ttl?: number;
+
+    /**
+     * Whether to receive your own packets.
+     */
+    loopback?: boolean;
+
+    /**
+     * Whether to set the reuseAddr option when creating the UDP socket.
+     * (requires node >=0.11.13)
+     */
+    reuseAddr?: boolean;
+}
+
+interface MulticastDns extends NodeJS.EventEmitter {
+
+    on(event: 'response', cb: (response: packet.Packet) => any): this;
+    on(event: 'query', cb: (query: packet.Packet) => any): this;
+
+    send(value: packet.Packet, cb?: Callback): void;
+    send(value: packet.Packet, rinfo: AddressInfo, cb?: Callback): void;
+
+    response(res: packet.Packet, cb?: Callback): void;
+    response(res: packet.Packet, rinfo: AddressInfo, cb?: Callback): void;
+
+    respond(res: packet.Packet, cb?: Callback): void;
+    respond(res: packet.Packet, rinfo: AddressInfo, cb?: Callback): void;
+
+    query(query: string | packet.Packet | packet.Question[], cb?: Callback): void;
+    query(query: packet.Packet | packet.Question[], rinfo: AddressInfo, cb?: Callback): void;
+    query(name: string, type: packet.RecordType, cb?: Callback): void;
+    query(name: string, type: packet.RecordType, rinfo: AddressInfo, cb?: Callback): void;
+
+    destroy(cb?: Callback): void;
+}
+
+export default function (opts?: MulticastDnsOptions): MulticastDns;

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "6.1.0",
   "description": "Low level multicast-dns implementation in pure javascript",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
-    "test": "standard && tape test.js"
+    "test": "standard && tape test.js",
+    "typing-test": "tsc --noemit typing-test.ts"
   },
   "bin": "cli.js",
   "dependencies": {
@@ -12,6 +14,7 @@
     "thunky": "^0.1.0"
   },
   "devDependencies": {
+    "@types/node": "^6.0.51",
     "standard": "^5.4.1",
     "tape": "^4.4.0"
   },

--- a/typing-test.ts
+++ b/typing-test.ts
@@ -1,0 +1,139 @@
+/*
+ * Tests the defined typings for the module. This code is not intended to make
+ * sense as an actual executable program; instead, it tests that common use
+ * cases of the library compile without typing errors and that the correct
+ * types are inferred where necessary.
+ */
+
+/// <reference types="node" />
+import * as packet from 'dns-packet';
+import * as multicastDns from './index';
+
+let mdns = multicastDns.default();
+let mdnsWithOptions = multicastDns.default({
+    interface: 'lo0',
+    ip: '127.0.0.1',
+    loopback: false,
+    multicast: true,
+    port: 1234,
+    ttl: 500,
+    reuseAddr: true
+});
+
+let callback = (err: any) => {
+    if (err) {
+        console.log('Failed to send mDNS query');
+    } else {
+        console.log('query sent');
+    }
+};
+
+let rinfo = {
+    address: '169.254.1.1',
+    family: 'ipv4',
+    port: 5353
+};
+
+let queryPacket: packet.Packet = {
+    questions: [{
+        name: 'testing.local',
+        type: 'A'
+    }]
+};
+
+let responsePacket: packet.Packet = {
+    type: 'response',
+    answers: [{
+        type: 'A',
+        name: 'testing.local',
+        data: '127.1.2.3'
+    }]
+};
+
+namespace QueryTests {
+    {
+        // query just using a name
+        mdns.query('testing.local');
+        mdns.query('testing.local', callback);
+
+        // query using a name and a type
+        mdns.query('testing.local', 'AAAA');
+        mdns.query('testing.local', 'AAAA', callback);
+
+        // query using a name and a type, on a specific address
+        mdns.query('testing.local', 'SRV', rinfo);
+        mdns.query('testing.local', 'SRV', rinfo, callback);
+
+        // query using a packet object
+        mdns.query(queryPacket);
+
+        // query using a list of questions
+        mdns.query([
+            { name: 'testing.local', type: 'A' },
+            { name: 'testing.local', type: 'AAAA' },
+            { name: 'testing.local', type: 'SRV' }
+        ]);
+    }
+}
+
+namespace SendTests {
+    {
+        mdns.send(queryPacket);
+        mdns.send(queryPacket, callback);
+
+        mdns.send(responsePacket, rinfo);
+        mdns.send(responsePacket, rinfo, callback);
+    }
+}
+
+namespace RespondTests {
+    {
+        mdns.respond(responsePacket);
+        mdns.respond(responsePacket, callback);
+
+        mdns.respond(responsePacket, rinfo);
+        mdns.respond(responsePacket, rinfo, callback);
+    }
+}
+
+namespace EventTests {
+    {
+        // capture a query response
+        mdns.on('response', (response) => {
+            console.log('got a response packet:', response);
+            response.answers!.forEach((answer) => {
+                // based on the answer type, we should be able to infer the correct
+                // data payload type
+                switch (answer.type) {
+                    case 'A':
+                        console.log('Answer for A lookup' + answer.data);
+                        break;
+                    case 'SRV':
+                        console.log('Answer for SRV lookup: '
+                            + '[' + answer.data.target + ':'
+                            + answer.data.port);
+                    default:
+                        console.log('Answer for some other type:' + answer.type);
+                }
+            });
+        });
+
+        // capture a query
+        mdns.on('query', (query) => {
+            console.log('got a query packet:', query);
+            query.questions!.forEach((question) => {
+                if (question.type === 'A') {
+                    console.log('query is for a hostname to address mapping');
+                }
+            });
+        });
+
+    }
+}
+
+namespace DestroyTests {
+    {
+        mdns.destroy();
+        mdns.destroy(callback);
+    }
+}


### PR DESCRIPTION
Typescript team prefers that typings are defined as part of the module wherever possible - will you accept these definitions as part of your project? If not, I can submit them to DefinitelyTyped.

Requires https://github.com/mafintosh/dns-packet/pull/2 to be submitted before this works.