### PR TITLE
Multi-interface support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Creates a new `mdns` instance. Options can contain the following
 ``` js
 {
   multicast: true // use udp multicasting
-  interface: '192.168.0.2' // explicitly specify a network interface. defaults to all
+  interface: '192.168.0.2' // explicitly specify a network interface or array of interfaces**
   port: 5353, // set the udp port
   ip: '224.0.0.251', // set the udp ip
   ttl: 255, // set the multicast ttl
@@ -122,6 +122,10 @@ Creates a new `mdns` instance. Options can contain the following
   reuseAddr: true // set the reuseAddr option when creating the socket (requires node >=0.11.13)
 }
 ```
+
+<sup>**</sup> The interface option should be specified on host systems with multiple network
+interface options. When not specified a single interface will be automatically chosen for
+broadcasting.
 
 #### `mdns.on('query', (packet, rinfo))`
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function (opts) {
   var bind = thunky(function (cb) {
     if (!port) return cb(null)
     socket.once('error', cb)
-    socket.bind(port, function () {
+    socket.bind(port, opts.interface, function () {
       socket.removeListener('error', cb)
       cb(null)
     })

--- a/index.js
+++ b/index.js
@@ -83,9 +83,9 @@ module.exports = function (opts) {
         } catch (err) {
           that.emit('error', err)
         }
-        socket.setMulticastTTL(opts.ttl || 255)
-        socket.setMulticastLoopback(opts.loopback !== false)
       })
+      socket.setMulticastTTL(opts.ttl || 255)
+      socket.setMulticastLoopback(opts.loopback !== false)
     }
   })
 

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = function (opts) {
         try {
           socket.addMembership(ip, iface)
         } catch (err) {
-          that.emit('error', err)
+          that.emit('warning', err)
         }
       })
       socket.setMulticastTTL(opts.ttl || 255)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multicast-dns",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Low level multicast-dns implementation in pure javascript",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I have been running this forked version of multicast-dns for a couple of months with no issues. It provides support for multiple network interface listening and queries. The other pull request that addresses this need is stalled so I thought I should provide the opportunity to merge this fork if the code changes are acceptable.

This change allows an array of interfaces to be specified in the options when creating an instance of multicast-dns. All specified interfaces will then be used to listen and a socket will be opened on each interface to send out queries.