### PR TITLE
fix: responses are authoritative

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ module.exports = function (opts) {
     if (Array.isArray(res)) res = {answers: res}
 
     res.type = 'response'
+    res.flags = (res.flags || 0) | packet.AUTHORITATIVE_ANSWER
     that.send(res, rinfo, cb)
   }
 

--- a/test.js
+++ b/test.js
@@ -222,4 +222,19 @@ tests.forEach(function (test) {
 
     dns.query('foo', 'A')
   })
+
+  test('Authoritive Answer bit', function (dns, t) {
+    dns.once('query', function (packet) {
+      dns.respond([])
+    })
+
+    dns.once('response', function (packet) {
+      t.ok(packet.flag_auth, 'should be set')
+      dns.destroy(function () {
+        t.end()
+      })
+    })
+
+    dns.query('foo', 'A')
+  })
 })


### PR DESCRIPTION
The AA bit must be set for all responses to a query according to [RFC 6762](https://tools.ietf.org/html/rfc6762#section-18.4).

> In response messages for Multicast domains, the Authoritative Answer
   bit MUST be set to one (not setting this bit would imply there's some
   other place where "better" information may be found) and MUST be
   ignored on reception.

Reported by https://github.com/libp2p/js-libp2p-mdns/issues/64