### PR TITLE
Cache the os.networkInterfaces() call

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,8 +159,9 @@ function defaultInterface () {
   return '127.0.0.1'
 }
 
+var _networks
 function allInterfaces () {
-  var networks = os.networkInterfaces()
+  var networks = _networks = (_networks ? _networks : os.networkInterfaces())
   var names = Object.keys(networks)
   var res = []
 


### PR DESCRIPTION
I found this call was eating some CPU time. Do we need to get fresh information on this call, or can we cache the result for the whole run?