### PR TITLE
Split out interface for binding UDP socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,13 @@ Creates a new `mdns` instance. Options can contain the following
 ``` js
 {
   multicast: true // use udp multicasting
-  interface: '192.168.0.2' // explicitly specify a network interface. defaults to all
+  interface: '192.168.0.2', // explicitly specify a network interface. defaults to all
+  bindAddress: '192.168.0.3', // what address to bind the socket on. defaults to undefined
   port: 5353, // set the udp port
   ip: '224.0.0.251', // set the udp ip
   ttl: 255, // set the multicast ttl
   loopback: true, // receive your own packets
-  reuseAddr: true // set the reuseAddr option when creating the socket (requires node >=0.11.13)
+  reuseAddr: true, // set the reuseAddr option when creating the socket (requires node >=0.11.13)
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = function (opts) {
   var bind = thunky(function (cb) {
     if (!port || opts.bind === false) return cb(null)
     socket.once('error', cb)
-    socket.bind(port, opts.interface, function () {
+    socket.bind(port, opts.bindAddress, function () {
       socket.removeListener('error', cb)
       cb(null)
     })


### PR DESCRIPTION
This is useful for when you want to use a specific multicast interface but don't want to use that IP address for binding the UDP socket.

Fixes #53 