### PR TITLE
feat: add exclusive option for underlying udp socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+npm-debug.log
 .idea

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Creates a new `mdns` instance. Options can contain the following
   ttl: 255, // set the multicast ttl
   loopback: true, // receive your own packets
   reuseAddr: true // set the reuseAddr option when creating the socket (requires node >=0.11.13)
+  exclusive: true // set to true to prevent cluster workers from using the same underlying socket handle
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = function (opts) {
   var ip = opts.ip || opts.host || (type === 'udp4' ? '224.0.0.251' : null)
   var me = {address: ip, port: port}
   var memberships = {}
+  var exclusive = opts.exclusive
   var destroyed = false
   var interval = null
 
@@ -62,7 +63,7 @@ module.exports = function (opts) {
   var bind = thunky(function (cb) {
     if (!port || opts.bind === false) return cb(null)
     socket.once('error', cb)
-    socket.bind(port, opts.interface, function () {
+    socket.bind({port: port, address: opts.interface, exclusive: exclusive}, function () {
       socket.removeListener('error', cb)
       cb(null)
     })


### PR DESCRIPTION
This commit adds the `exclusive` option to configure the udp socket bind call.
Adding this option allows a worker of node cluster to use the multicast-dns module without sharing the underlying udp socket with other workers of the cluster.