### PR TITLE
fix: intermittent error when asking for interfaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ var thunky = require('thunky')
 var events = require('events')
 var os = require('os')
 
+var networks = os.networkInterfaces()
+
 var noop = function () {}
 
 module.exports = function (opts) {
@@ -146,7 +148,6 @@ module.exports = function (opts) {
 }
 
 function defaultInterface () {
-  var networks = os.networkInterfaces()
   var names = Object.keys(networks)
 
   for (var i = 0; i < names.length; i++) {
@@ -164,7 +165,6 @@ function defaultInterface () {
 }
 
 function allInterfaces () {
-  var networks = os.networkInterfaces()
   var names = Object.keys(networks)
   var res = []
 


### PR DESCRIPTION
I’m seeing a strange error in newer versions of Node.js. For some reason, libuv doesn’t like it when you ask for the network interfaces too much. Eventually you get an error like this:

```
os.js:64
      throw new ERR_SYSTEM_ERROR(ctx);
      ^
  
SystemError [ERR_SYSTEM_ERROR]: A system error occurred: uv_interface_addresses returned Unknown system error 24
(Unknown system error 24)
    at Object.networkInterfaces (os.js:203:16)
    at allInterfaces (/root/IPSQL/node_modules/multicast-dns/index.js:167:21)
    at Timeout.that.update [as _onTimeout] (/root/IPSQL/node_modules/multicast-dns/index.js:124:63)
    at listOnTimeout (internal/timers.js:554:17)
    at processTimers (internal/timers.js:497:7) {
  code: 'ERR_SYSTEM_ERROR',
  info: {
    errno: 24,
    code: 'Unknown system error 24',
    message: 'Unknown system error 24',
    syscall: 'uv_interface_addresses'
  },  
  errno: [Getter/Setter],
  syscall: [Getter/Setter]
}
```

It seems very unnecessary to ask for the network interfaces so often since they aren’t expected to change during the lifecycle of the program so this is also just more efficient.