### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ A packet has the following format
 ``` js
 {
   questions: [{
-    name:'brunhilde.local',
-    type:'A'
+    name: 'brunhilde.local',
+    type: 'A'
   }],
   answers: [{
-    name:'brunhilde.local',
-    type:'A',
-    ttl:seconds,
-    data:(record type specific data)
+    name: 'brunhilde.local',
+    type: 'A',
+    ttl: seconds,
+    data: (record type specific data)
   }],
   additionals: [
     (same format as answers)
@@ -167,8 +167,8 @@ mdns.respond({
     name: 'my-service',
     type: 'SRV',
     data: {
-      port:9999,
-      weigth: 0,
+      port: 9999,
+      weight: 0,
       priority: 10,
       target: 'my-service.example.com'
     }


### PR DESCRIPTION
Minor typo correction:  The property `weight` was misspelled `weigth`.  Added a missing space in code formatting in a few places e.g.: `port:9999` -> `port: 9999`.